### PR TITLE
feat: DRM playback support

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "concurrently": "^6.0.2",
     "copy-webpack-plugin": "^8.1.1",
     "cross-env": "7.0.3",
-    "electron": "^16.0.4",
+    "electron": "https://github.com/castlabs/electron-releases#v16.0.4+wvcus.1",
     "electron-builder": "22.14.5",
     "electron-updater": "4.6.1",
     "eslint": "^7.24.0",
@@ -120,5 +120,10 @@
     "react-image-fallback": "^8.0.0",
     "react-query": "^3.28.0",
     "react-use": "^17.3.1"
+  },
+  "build": {
+    "electronDownload": {
+      "mirror": "https://github.com/castlabs/electron-releases/releases/download/v"
+    }
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { ipcMain, app, webContents } from 'electron';
+import { ipcMain, app, components, webContents } from 'electron';
 import { setIpcMain } from '@wexond/rpc-electron';
 setIpcMain(ipcMain);
 
@@ -16,7 +16,6 @@ export const isNightly = app.name === 'skye-nightly';
 app.name = isNightly ? 'Skye Nightly' : 'Skye';
 
 (process.env as any)['ELECTRON_DISABLE_SECURITY_WARNINGS'] = true;
-
 app.commandLine.appendSwitch('--enable-transparent-visuals');
 app.commandLine.appendSwitch(
   'enable-features',
@@ -74,8 +73,11 @@ ipcMain.handle(
 
 // We need to prevent extension background pages from being garbage collected.
 const backgroundPages: Electron.WebContents[] = [];
-
-app.on('web-contents-created', (e, webContents) => {
-  if (webContents.getType() === 'backgroundPage')
-    backgroundPages.push(webContents);
+app.whenReady().then(async () => {
+  await components.whenReady();
+  console.log('components ready:', components.status());
+  app.on('web-contents-created', (e, webContents) => {
+    if (webContents.getType() === 'backgroundPage')
+      backgroundPages.push(webContents);
+  })
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,9 +677,9 @@
   integrity sha512-KB0sixD67CeecHC33MYn+eYARkqTheIRNuu97y2XMjR7Wu3XibO1vaY6VBV6O/a89SPI81cEUIYT87UqUWlZNw==
 
 "@types/node@^14.6.2":
-  version "14.17.34"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.34.tgz#fe4b38b3f07617c0fa31ae923fca9249641038f0"
-  integrity sha512-USUftMYpmuMzeWobskoPfzDi+vkpe0dvcOBRNOscFrGxVp4jomnRxWuVohgqBow2xyIPC0S3gjxV/5079jhmDg==
+  version "14.18.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.0.tgz#98df2397f6936bfbff4f089e40e06fa5dd88d32a"
+  integrity sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"
@@ -2595,10 +2595,9 @@ electron-updater@4.6.1:
     lodash.isequal "^4.5.0"
     semver "^7.3.5"
 
-electron@^16.0.4:
+"electron@https://github.com/castlabs/electron-releases#v16.0.4+wvcus.1":
   version "16.0.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-16.0.4.tgz#87dfe21d17608537fc6df292c437362297566a73"
-  integrity sha512-IptwmowvMP1SFOmZLh6rrURwfnOxbDBXBRBcaOdfBM5I+B9mgtdNwzNC3ymFFNzEkZUwdOyg9fu3iyjAAQIQgw==
+  resolved "https://github.com/castlabs/electron-releases#9cf1d60af1231923ab1676c36181ed90a01fa358"
   dependencies:
     "@electron/get" "^1.13.0"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
#### Description of Change
This changes the electron version to one provided by cast labs as castlab's fork support DRM playback through widevine. This is a initial development support, release builds will need to be signed.

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] PR title follows semantic [commit guidelines](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)
- [X ] PR release notes describe the change, and are capitalized, punctuated, and past tense.

#### Release Notes

Notes: Adds DRM playback through widevine fixing #5 
<!-- Please add a one-line description for users to read in the release notes, or 'none' if no notes relevant to users.
